### PR TITLE
Tokenomics + Handling API keys as secrets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -40,8 +40,8 @@ deploy-all:
 	make deploy-madt && \
 	make deploy-usdt && \
 	make setup-functions && \
-	make send-request && \
-	make deploy-vault
+	make deploy-vault && \
+	make send-request
 
 # Interactions with the DON via the DataProvider contract
 send-request:
@@ -74,6 +74,10 @@ deposit-collateral:
 # Redeem collateral
 redeem-collateral:
 	forge script script/VaultInteractions.s.sol:VaultInteractions --sig "redeemCollateral(uint256)" $(AMOUNT) --rpc-url http://localhost:8545 --private-key $(DEFAULT_ANVIL_KEY) --broadcast -vv
+
+# Rebase
+rebase:
+	forge script script/VaultInteractions.s.sol:VaultInteractions --sig "rebase()" --rpc-url http://localhost:8545 --private-key $(DEFAULT_ANVIL_KEY) --broadcast -vv
 
 NETWORK_ARGS := --rpc-url http://localhost:8545 --private-key $(DEFAULT_ANVIL_KEY) --broadcast
 

--- a/Makefile
+++ b/Makefile
@@ -38,10 +38,10 @@ setup-functions:
 
 # Interactions with the DON via the DataProvider contract
 send-request:
-	forge script script/Interactions.s.sol:Interactions --sig "sendRequest()" --rpc-url http://localhost:8545 --private-key $(DEFAULT_ANVIL_KEY) --broadcast -vvvvv
+	forge script script/Interactions.s.sol:Interactions --sig "sendRequest()" --rpc-url http://localhost:8545 --private-key $(DEFAULT_ANVIL_KEY) --broadcast -vv
 
 get-last-response:
-	forge script script/Interactions.s.sol:Interactions --sig "getLastResponse()" --rpc-url http://localhost:8545 --private-key $(DEFAULT_ANVIL_KEY) --broadcast -vvvvv
+	forge script script/Interactions.s.sol:Interactions --sig "getLastResponse()" --rpc-url http://localhost:8545 --private-key $(DEFAULT_ANVIL_KEY) --broadcast -vv
 
 get-last-error:
 	cast call $(CONTRACT_ADDRESS) "getLastError()" --rpc-url http://localhost:8545 --private-key $(DEFAULT_ANVIL_KEY)
@@ -53,17 +53,20 @@ get-last-request-id:
 deploy-madt:
 	forge script script/DeployMADT.s.sol:DeployMADT --rpc-url http://localhost:8545 --private-key $(DEFAULT_ANVIL_KEY) --broadcast
 
+deploy-usdt:
+	forge script script/DeployMockUSDT.s.sol:DeployMockUSDT --rpc-url http://localhost:8545 --private-key $(DEFAULT_ANVIL_KEY) --broadcast
+
 deploy-vault:
-	forge script script/DeployVault.s.sol:DeployVault --rpc-url http://localhost:8545 --private-key $(DEFAULT_ANVIL_KEY) --broadcast -vvvvv
+	forge script script/DeployVault.s.sol:DeployVault --rpc-url http://localhost:8545 --private-key $(DEFAULT_ANVIL_KEY) --broadcast -vv
 
 # Interactions with the Vault contract
 # Deposit collateral
 deposit-collateral:
-	forge script script/VaultInteractions.s.sol:VaultInteractions --sig "depositCollateral()" --rpc-url http://localhost:8545 --private-key $(DEFAULT_ANVIL_KEY) --broadcast -vvvvv
+	forge script script/VaultInteractions.s.sol:VaultInteractions --sig "depositCollateral()" --rpc-url http://localhost:8545 --private-key $(DEFAULT_ANVIL_KEY) --broadcast -vv
 
 # Redeem collateral
 redeem-collateral:
-	forge script script/VaultInteractions.s.sol:VaultInteractions --sig "redeemCollateral(uint256)" --rpc-url http://localhost:8545 --private-key $(DEFAULT_ANVIL_KEY) --broadcast -vvvvv
+	forge script script/VaultInteractions.s.sol:VaultInteractions --sig "redeemCollateral(uint256)" $(AMOUNT) --rpc-url http://localhost:8545 --private-key $(DEFAULT_ANVIL_KEY) --broadcast -vv
 
 NETWORK_ARGS := --rpc-url http://localhost:8545 --private-key $(DEFAULT_ANVIL_KEY) --broadcast
 

--- a/Makefile
+++ b/Makefile
@@ -36,6 +36,13 @@ simulate-don:
 setup-functions:
 	forge script script/FunctionsScript.s.sol:FunctionsScript --rpc-url http://localhost:8545 --private-key $(DEFAULT_ANVIL_KEY) --broadcast
 
+deploy-all:
+	make deploy-madt && \
+	make deploy-usdt && \
+	make setup-functions && \
+	make send-request && \
+	make deploy-vault
+
 # Interactions with the DON via the DataProvider contract
 send-request:
 	forge script script/Interactions.s.sol:Interactions --sig "sendRequest()" --rpc-url http://localhost:8545 --private-key $(DEFAULT_ANVIL_KEY) --broadcast -vv

--- a/Makefile
+++ b/Makefile
@@ -51,7 +51,7 @@ get-last-response:
 	forge script script/Interactions.s.sol:Interactions --sig "getLastResponse()" --rpc-url http://localhost:8545 --private-key $(DEFAULT_ANVIL_KEY) --broadcast -vv
 
 get-last-error:
-	cast call $(CONTRACT_ADDRESS) "getLastError()" --rpc-url http://localhost:8545 --private-key $(DEFAULT_ANVIL_KEY)
+	forge script script/Interactions.s.sol:Interactions --sig "getLastError()" --rpc-url http://localhost:8545 --private-key $(DEFAULT_ANVIL_KEY) --broadcast -vv
 
 get-last-request-id:
 	cast call $(CONTRACT_ADDRESS) "getLastRequestId()" --rpc-url http://localhost:8545 --private-key $(DEFAULT_ANVIL_KEY)

--- a/don-simulator/package-lock.json
+++ b/don-simulator/package-lock.json
@@ -6,6 +6,7 @@
     "": {
       "dependencies": {
         "cbor": "^10.0.3",
+        "dotenv": "^16.4.7",
         "ethers": "^5.7.2"
       },
       "devDependencies": {
@@ -757,6 +758,18 @@
       },
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/dotenv": {
+      "version": "16.4.7",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.4.7.tgz",
+      "integrity": "sha512-47qPchRCykZC03FhkYAhrvwU4xDBFIj1QPqaarj6mdM/hgUzfPHcpkHJOn3mJAufFeeAxAzeGsr5X0M4k6fLZQ==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
       }
     },
     "node_modules/elliptic": {

--- a/don-simulator/package.json
+++ b/don-simulator/package.json
@@ -4,6 +4,7 @@
   },
   "dependencies": {
     "cbor": "^10.0.3",
+    "dotenv": "^16.4.7",
     "ethers": "^5.7.2"
   }
 }

--- a/don-simulator/src/config.js
+++ b/don-simulator/src/config.js
@@ -1,0 +1,33 @@
+require("dotenv").config();
+const Location = {
+  Inline: 0,
+  Remote: 1,
+  DONHosted: 2,
+};
+
+const CodeLanguage = {
+  JavaScript: 0,
+};
+
+const ReturnType = {
+  uint: "uint256",
+  uint256: "uint256",
+  int: "int256",
+  int256: "int256",
+  string: "string",
+  bytes: "bytes",
+};
+
+// Configure the request by setting the fields below
+const requestConfig = {
+  // Location of source code (only Inline is currently supported)
+  codeLocation: Location.Inline,
+  // Optional. Secrets can be accessed within the source code with `secrets.varName` (ie: secrets.apiKey). The secrets object can only contain string values.
+  secrets: { apiKey: process.env.RANDOM_ENV ?? "salam2" },
+  // Code language (only JavaScript is currently supported)
+  codeLanguage: CodeLanguage.JavaScript,
+  // Expected type of the returned value
+  expectedReturnType: ReturnType.string,
+};
+
+module.exports = requestConfig;

--- a/don-simulator/src/config.js
+++ b/don-simulator/src/config.js
@@ -23,11 +23,14 @@ const requestConfig = {
   // Location of source code (only Inline is currently supported)
   codeLocation: Location.Inline,
   // Optional. Secrets can be accessed within the source code with `secrets.varName` (ie: secrets.apiKey). The secrets object can only contain string values.
-  secrets: { apiKey: process.env.RANDOM_ENV ?? "salam2" },
+  secrets: {
+    exchangeRateApiKey: process.env.EXCH_RATE_KEY ?? "",
+    currencyApiKey: process.env.CURRENCY_KEY ?? "",
+  },
   // Code language (only JavaScript is currently supported)
   codeLanguage: CodeLanguage.JavaScript,
   // Expected type of the returned value
-  expectedReturnType: ReturnType.string,
+  expectedReturnType: ReturnType.uint256,
 };
 
 module.exports = requestConfig;

--- a/don-simulator/src/localFunctionsTestnet.ts
+++ b/don-simulator/src/localFunctionsTestnet.ts
@@ -495,7 +495,10 @@ if (require.main === module) {
     try {
       const args = process.argv.slice(2);
       const coordinatorAddress = args[0];
-      const configPath = path.join(process.cwd(), "don-simulator/src/config.js");
+      const configPath = path.join(
+        process.cwd(),
+        "don-simulator/src/config.js"
+      );
       console.log("Starting local Functions testnet...");
       const testnet = await startLocalFunctionsTestnet(
         coordinatorAddress,

--- a/don-simulator/src/localFunctionsTestnet.ts
+++ b/don-simulator/src/localFunctionsTestnet.ts
@@ -31,6 +31,7 @@ import type {
   FunctionsContracts,
   RequestEventData,
 } from "./types";
+import path from "path";
 
 export const startLocalFunctionsTestnet = async (
   coordinatorAddress?: string,
@@ -494,8 +495,12 @@ if (require.main === module) {
     try {
       const args = process.argv.slice(2);
       const coordinatorAddress = args[0];
+      const configPath = path.join(process.cwd(), "don-simulator/src/config.js");
       console.log("Starting local Functions testnet...");
-      const testnet = await startLocalFunctionsTestnet(coordinatorAddress);
+      const testnet = await startLocalFunctionsTestnet(
+        coordinatorAddress,
+        configPath
+      );
       console.log("Local Functions testnet started successfully");
 
       // Keep the process running

--- a/don-simulator/src/source/source.js
+++ b/don-simulator/src/source/source.js
@@ -1,51 +1,51 @@
-// Discontinued because of API changes.
-// const bkamAPI = Functions.makeHttpRequest({
-//   url: `https://api.centralbankofmorocco.ma/cours/Version1/api/CoursVirement?libDevise=USD`,
-//   headers: { "Ocp-Apim-Subscription-Key": secrets.BKAM_KEY },
-// })
+// // Discontinued because of API changes.
+// // const bkamAPI = Functions.makeHttpRequest({
+// //   url: `https://api.centralbankofmorocco.ma/cours/Version1/api/CoursVirement?libDevise=USD`,
+// //   headers: { "Ocp-Apim-Subscription-Key": secrets.BKAM_KEY },
+// // })
 
-if (secrets.exchangeRateApiKey.length === 0) {
-  throw Error("No valid EXCH_RATE_KEY was supplied");
-}
+// if (secrets.exchangeRateApiKey.length === 0) {
+//   throw Error("No valid EXCH_RATE_KEY was supplied");
+// }
 
-if (secrets.currencyApiKey.length === 0) {
-  throw Error("No valid CURRENCY_KEY was supplied");
-}
+// if (secrets.currencyApiKey.length === 0) {
+//   throw Error("No valid CURRENCY_KEY was supplied");
+// }
 
-const exchRateAPI = Functions.makeHttpRequest({
-  url: `https://v6.exchangerate-api.com/v6/${secrets.exchangeRateApiKey}/pair/MAD/USD`,
-});
+// const exchRateAPI = Functions.makeHttpRequest({
+//   url: `https://v6.exchangerate-api.com/v6/${secrets.exchangeRateApiKey}/pair/MAD/USD`,
+// });
 
-const currencyAPI = Functions.makeHttpRequest({
-  url: `https://api.currencyapi.com/v3/latest?apikey=${secrets.currencyApiKey}&currencies=USD&base_currency=MAD`,
-});
+// const currencyAPI = Functions.makeHttpRequest({
+//   url: `https://api.currencyapi.com/v3/latest?apikey=${secrets.currencyApiKey}&currencies=USD&base_currency=MAD`,
+// });
 
-const [exchRateAPIResponse, currencyAPIResponse] = await Promise.all([
-  exchRateAPI,
-  currencyAPI,
-]);
+// const [exchRateAPIResponse, currencyAPIResponse] = await Promise.all([
+//   exchRateAPI,
+//   currencyAPI,
+// ]);
 
-const prices = [];
-if (!exchRateAPIResponse.error) {
-  prices.push(exchRateAPIResponse.data.conversion_rate);
-} else {
-  console.log("ExchangeRateAPI Error");
-  throw Error(JSON.stringify(exchRateAPIResponse));
-}
-if (!currencyAPIResponse.error) {
-  prices.push(currencyAPIResponse.data.data.USD.value);
-} else {
-  console.log("CurrencyAPI Error");
-  throw Error(JSON.stringify(currencyAPIResponse));
-}
+// const prices = [];
+// if (!exchRateAPIResponse.error) {
+//   prices.push(exchRateAPIResponse.data.conversion_rate);
+// } else {
+//   console.log("ExchangeRateAPI Error");
+//   throw Error(JSON.stringify(exchRateAPIResponse));
+// }
+// if (!currencyAPIResponse.error) {
+//   prices.push(currencyAPIResponse.data.data.USD.value);
+// } else {
+//   console.log("CurrencyAPI Error");
+//   throw Error(JSON.stringify(currencyAPIResponse));
+// }
 
-if (prices.length < 2) {
-  // If an error is thrown, it will be returned back to the smart contract
-  throw Error("More than 1 API failed");
-}
+// if (prices.length < 2) {
+//   // If an error is thrown, it will be returned back to the smart contract
+//   throw Error("More than 1 API failed");
+// }
 
-const medianRate = prices.sort((a, b) => a - b)[Math.round(prices.length / 2)];
-console.log(`Median MAD rate: $${medianRate.toFixed(2)}`);
+// const medianRate = prices.sort((a, b) => a - b)[Math.round(prices.length / 2)];
+// console.log(`Median MAD rate: $${medianRate.toFixed(2)}`);
 
-return Functions.encodeUint256(Math.round(medianRate * 100));
-// return Functions.encodeUint256(Math.round(Math.random() * 10000))
+// return Functions.encodeUint256(Math.round(medianRate * 100));
+return Functions.encodeUint256(11);

--- a/don-simulator/src/source/source.js
+++ b/don-simulator/src/source/source.js
@@ -1,5 +1,51 @@
-if (secrets.apiKey === "salam") {
-  return Functions.encodeUint256(0.4 * 100);
-} else {
-  return Functions.encodeUint256(0.6 * 100);
+// Discontinued because of API changes.
+// const bkamAPI = Functions.makeHttpRequest({
+//   url: `https://api.centralbankofmorocco.ma/cours/Version1/api/CoursVirement?libDevise=USD`,
+//   headers: { "Ocp-Apim-Subscription-Key": secrets.BKAM_KEY },
+// })
+
+if (secrets.exchangeRateApiKey.length === 0) {
+  throw Error("No valid EXCH_RATE_KEY was supplied");
 }
+
+if (secrets.currencyApiKey.length === 0) {
+  throw Error("No valid CURRENCY_KEY was supplied");
+}
+
+const exchRateAPI = Functions.makeHttpRequest({
+  url: `https://v6.exchangerate-api.com/v6/${secrets.exchangeRateApiKey}/pair/MAD/USD`,
+});
+
+const currencyAPI = Functions.makeHttpRequest({
+  url: `https://api.currencyapi.com/v3/latest?apikey=${secrets.currencyApiKey}&currencies=USD&base_currency=MAD`,
+});
+
+const [exchRateAPIResponse, currencyAPIResponse] = await Promise.all([
+  exchRateAPI,
+  currencyAPI,
+]);
+
+const prices = [];
+if (!exchRateAPIResponse.error) {
+  prices.push(exchRateAPIResponse.data.conversion_rate);
+} else {
+  console.log("ExchangeRateAPI Error");
+  throw Error(JSON.stringify(exchRateAPIResponse));
+}
+if (!currencyAPIResponse.error) {
+  prices.push(currencyAPIResponse.data.data.USD.value);
+} else {
+  console.log("CurrencyAPI Error");
+  throw Error(JSON.stringify(currencyAPIResponse));
+}
+
+if (prices.length < 2) {
+  // If an error is thrown, it will be returned back to the smart contract
+  throw Error("More than 1 API failed");
+}
+
+const medianRate = prices.sort((a, b) => a - b)[Math.round(prices.length / 2)];
+console.log(`Median MAD rate: $${medianRate.toFixed(2)}`);
+
+return Functions.encodeUint256(Math.round(medianRate * 100));
+// return Functions.encodeUint256(Math.round(Math.random() * 10000))

--- a/don-simulator/src/source/source.js
+++ b/don-simulator/src/source/source.js
@@ -1,2 +1,5 @@
-return Functions.encodeUint256(0.1 * 100);
- 
+if (secrets.apiKey === "salam") {
+  return Functions.encodeUint256(0.4 * 100);
+} else {
+  return Functions.encodeUint256(0.6 * 100);
+}

--- a/don-simulator/src/test.js
+++ b/don-simulator/src/test.js
@@ -1,0 +1,3 @@
+require("dotenv").config();
+
+console.log(process.env.EXCH_RATE_KEY);

--- a/script/DeployMockUSDT.s.sol
+++ b/script/DeployMockUSDT.s.sol
@@ -1,0 +1,13 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.24;
+
+import {Script} from "forge-std/Script.sol";
+import {MockUSDT} from "../src/MockUSDT.sol";
+
+contract DeployMockUSDT is Script {
+    function run() public {
+        vm.startBroadcast(vm.envUint("PRIVATE_KEY"));
+        new MockUSDT();
+        vm.stopBroadcast();
+    }
+}

--- a/script/DeployVault.s.sol
+++ b/script/DeployVault.s.sol
@@ -11,15 +11,15 @@ import {IERC20} from "openzeppelin-contracts/contracts/token/ERC20/IERC20.sol";
 import {DevOpsTools} from "lib/foundry-devops/src/DevOpsTools.sol";
 
 contract DeployVault is Script, HelperConfig {
-    IDataProvider public dataProvider;
-    address contractAddress = DevOpsTools.get_most_recent_deployment("DataProvider", block.chainid);
-    address MADTAddress = DevOpsTools.get_most_recent_deployment("MADT", block.chainid);
-
-    MADT public madt = MADT(MADTAddress);
-
     function run() public {
+        address contractAddress = DevOpsTools.get_most_recent_deployment("DataProvider", block.chainid);
+        address MADTAddress = DevOpsTools.get_most_recent_deployment("MADT", block.chainid);
+
+        MADT madt = MADT(MADTAddress);
+
         vm.startBroadcast(vm.envUint("PRIVATE_KEY"));
-        dataProvider = IDataProvider(contractAddress);
+        console.log("Deploying Vault..");
+        IDataProvider dataProvider = IDataProvider(contractAddress);
         IERC20 usdt = IERC20(getNetworkConfig().usdToken);
         Vault vault = new Vault(dataProvider, madt, usdt);
         madt.setVault(address(vault));

--- a/script/DeployVault.s.sol
+++ b/script/DeployVault.s.sol
@@ -22,7 +22,7 @@ contract DeployVault is Script, HelperConfig {
         dataProvider = IDataProvider(contractAddress);
         IERC20 usdt = IERC20(getNetworkConfig().usdToken);
         Vault vault = new Vault(dataProvider, madt, usdt);
-        // madt.setVault(address(vault));
+        madt.setVault(address(vault));
         vm.stopBroadcast();
     }
 }

--- a/script/HelperConfig.s.sol
+++ b/script/HelperConfig.s.sol
@@ -5,12 +5,15 @@ import {Script} from "forge-std/Script.sol";
 import {console} from "forge-std/console.sol";
 
 import {MockUSDT} from "../src/MockUSDT.sol";
+import {DevOpsTools} from "lib/foundry-devops/src/DevOpsTools.sol";
 
 contract HelperConfig is Script {
     // If we are on a local chain, we deploy the mock contract
     // Otherwise, we fetch the existing address from the live network
 
     uint256 public constant ETH_SEPOLIA_CHAIN_ID = 11155111;
+    address public usdtAddress =
+        DevOpsTools.get_most_recent_deployment("MockUSDT", block.chainid);
 
     struct NetworkConfig {
         address linkToken;
@@ -32,7 +35,11 @@ contract HelperConfig is Script {
         }
     }
 
-    function getSepoliaEthConfig() public pure returns (NetworkConfig memory sepoliaConfig) {
+    function getSepoliaEthConfig()
+        public
+        pure
+        returns (NetworkConfig memory sepoliaConfig)
+    {
         sepoliaConfig = NetworkConfig({
             linkToken: 0x779877A7B0D9E8603169DdbD7836e478b4624789,
             usdToken: 0x5f4eC3Df9cbd43714FE2740f5E3616155c5b8419,
@@ -45,12 +52,13 @@ contract HelperConfig is Script {
         return sepoliaConfig;
     }
 
-    function getAnvilEthConfig() public returns (NetworkConfig memory anvilConfig) {
-        MockUSDT usdt = new MockUSDT();
-
+    function getAnvilEthConfig()
+        public
+        returns (NetworkConfig memory anvilConfig)
+    {
         anvilConfig = NetworkConfig({
             linkToken: vm.envAddress("LINK_TOKEN_ADDRESS"),
-            usdToken: address(usdt),
+            usdToken: usdtAddress,
             subscriptionId: 1,
             donId: stringToBytes32(vm.envString("DON_ID")),
             router: vm.envAddress("FUNCTIONS_ROUTER_ADDRESS"),
@@ -65,7 +73,9 @@ contract HelperConfig is Script {
         return activeNetworkConfig;
     }
 
-    function stringToBytes32(string memory source) public pure returns (bytes32 result) {
+    function stringToBytes32(
+        string memory source
+    ) public pure returns (bytes32 result) {
         bytes memory tempEmptyStringTest = bytes(source);
         if (tempEmptyStringTest.length == 0) {
             return 0x0;

--- a/script/HelperConfig.s.sol
+++ b/script/HelperConfig.s.sol
@@ -12,8 +12,7 @@ contract HelperConfig is Script {
     // Otherwise, we fetch the existing address from the live network
 
     uint256 public constant ETH_SEPOLIA_CHAIN_ID = 11155111;
-    address public usdtAddress =
-        DevOpsTools.get_most_recent_deployment("MockUSDT", block.chainid);
+    address public usdtAddress = DevOpsTools.get_most_recent_deployment("MockUSDT", block.chainid);
 
     struct NetworkConfig {
         address linkToken;
@@ -35,11 +34,7 @@ contract HelperConfig is Script {
         }
     }
 
-    function getSepoliaEthConfig()
-        public
-        pure
-        returns (NetworkConfig memory sepoliaConfig)
-    {
+    function getSepoliaEthConfig() public pure returns (NetworkConfig memory sepoliaConfig) {
         sepoliaConfig = NetworkConfig({
             linkToken: 0x779877A7B0D9E8603169DdbD7836e478b4624789,
             usdToken: 0x5f4eC3Df9cbd43714FE2740f5E3616155c5b8419,
@@ -52,10 +47,7 @@ contract HelperConfig is Script {
         return sepoliaConfig;
     }
 
-    function getAnvilEthConfig()
-        public
-        returns (NetworkConfig memory anvilConfig)
-    {
+    function getAnvilEthConfig() public returns (NetworkConfig memory anvilConfig) {
         anvilConfig = NetworkConfig({
             linkToken: vm.envAddress("LINK_TOKEN_ADDRESS"),
             usdToken: usdtAddress,
@@ -73,9 +65,7 @@ contract HelperConfig is Script {
         return activeNetworkConfig;
     }
 
-    function stringToBytes32(
-        string memory source
-    ) public pure returns (bytes32 result) {
+    function stringToBytes32(string memory source) public pure returns (bytes32 result) {
         bytes memory tempEmptyStringTest = bytes(source);
         if (tempEmptyStringTest.length == 0) {
             return 0x0;

--- a/script/Interactions.s.sol
+++ b/script/Interactions.s.sol
@@ -15,9 +15,9 @@ contract Interactions is Script, HelperConfig {
     function getLastResponse() public returns (uint256) {
         vm.startBroadcast(vm.envUint("PRIVATE_KEY"));
         dataProvider = IDataProvider(contractAddress);
-        bytes memory response = dataProvider.getLastResponse();
-        return abi.decode(response, (uint256));
+        uint256 madValue = dataProvider.getMADValueInUSD();
         vm.stopBroadcast();
+        return madValue;
     }
 
     function sendRequest() public {

--- a/script/VaultInteractions.s.sol
+++ b/script/VaultInteractions.s.sol
@@ -8,10 +8,10 @@ import {FunctionsScript} from "./FunctionsScript.s.sol";
 import {Vault} from "../src/Vault.sol";
 import {DevOpsTools} from "lib/foundry-devops/src/DevOpsTools.sol";
 import {MockUSDT} from "../src/MockUSDT.sol";
+
 contract VaultInteractions is Script, HelperConfig {
     IDataProvider public dataProvider;
-    address contractAddress =
-        DevOpsTools.get_most_recent_deployment("Vault", block.chainid);
+    address contractAddress = DevOpsTools.get_most_recent_deployment("Vault", block.chainid);
 
     Vault public vault = Vault(contractAddress);
     MockUSDT public usdt = MockUSDT(usdtAddress);

--- a/script/VaultInteractions.s.sol
+++ b/script/VaultInteractions.s.sol
@@ -28,4 +28,10 @@ contract VaultInteractions is Script, HelperConfig {
         vault.redeemCollateral(amountInUsd);
         vm.stopBroadcast();
     }
+
+    function rebase() public {
+        vm.startBroadcast();
+        vault.rebase();
+        vm.stopBroadcast();
+    }
 }

--- a/script/VaultInteractions.s.sol
+++ b/script/VaultInteractions.s.sol
@@ -7,16 +7,25 @@ import {IDataProvider} from "../src/interfaces/IDataProvider.sol";
 import {FunctionsScript} from "./FunctionsScript.s.sol";
 import {Vault} from "../src/Vault.sol";
 import {DevOpsTools} from "lib/foundry-devops/src/DevOpsTools.sol";
-
+import {MockUSDT} from "../src/MockUSDT.sol";
 contract VaultInteractions is Script, HelperConfig {
     IDataProvider public dataProvider;
-    address contractAddress = DevOpsTools.get_most_recent_deployment("Vault", block.chainid);
+    address contractAddress =
+        DevOpsTools.get_most_recent_deployment("Vault", block.chainid);
 
     Vault public vault = Vault(contractAddress);
+    MockUSDT public usdt = MockUSDT(usdtAddress);
 
     function depositCollateral() public {
         vm.startBroadcast();
-        vault.depositCollateral(100);
+        usdt.approve(contractAddress, 100000000000000000000000000000);
+        vault.depositCollateral(12500);
+        vm.stopBroadcast();
+    }
+
+    function redeemCollateral(uint256 amountInUsd) public {
+        vm.startBroadcast();
+        vault.redeemCollateral(amountInUsd);
         vm.stopBroadcast();
     }
 }

--- a/src/MADT.sol
+++ b/src/MADT.sol
@@ -30,4 +30,8 @@ contract MADT is ERC20, Ownable {
     function burn(address from, uint256 amount) public onlyVault {
         _burn(from, amount);
     }
+
+    function decimals() public pure override returns (uint8) {
+        return 6;
+    }
 }

--- a/src/MADT.sol
+++ b/src/MADT.sol
@@ -36,19 +36,12 @@ contract MADT is ERC20, Ownable {
         return (super.balanceOf(account) * rebaseFactor) / 1e18;
     }
 
-    function transfer(
-        address to,
-        uint256 amount
-    ) public override returns (bool) {
+    function transfer(address to, uint256 amount) public override returns (bool) {
         uint256 scaledAmount = (amount * 1e18) / rebaseFactor;
         return super.transfer(to, scaledAmount);
     }
 
-    function transferFrom(
-        address from,
-        address to,
-        uint256 amount
-    ) public override returns (bool) {
+    function transferFrom(address from, address to, uint256 amount) public override returns (bool) {
         uint256 scaledAmount = (amount * 1e18) / rebaseFactor;
         return super.transferFrom(from, to, scaledAmount);
     }

--- a/src/MADT.sol
+++ b/src/MADT.sol
@@ -10,6 +10,7 @@ contract MADT is ERC20, Ownable {
     error MADT__InvalidVaultAddress();
 
     address public vault;
+    uint256 public rebaseFactor = 1e18;
 
     constructor() ERC20("Tokenized MAD", "MADT") Ownable(msg.sender) {}
 
@@ -29,6 +30,39 @@ contract MADT is ERC20, Ownable {
 
     function burn(address from, uint256 amount) public onlyVault {
         _burn(from, amount);
+    }
+
+    function balanceOf(address account) public view override returns (uint256) {
+        return (super.balanceOf(account) * rebaseFactor) / 1e18;
+    }
+
+    function transfer(
+        address to,
+        uint256 amount
+    ) public override returns (bool) {
+        uint256 scaledAmount = (amount * 1e18) / rebaseFactor;
+        return super.transfer(to, scaledAmount);
+    }
+
+    function transferFrom(
+        address from,
+        address to,
+        uint256 amount
+    ) public override returns (bool) {
+        uint256 scaledAmount = (amount * 1e18) / rebaseFactor;
+        return super.transferFrom(from, to, scaledAmount);
+    }
+
+    function rebase(uint256 madtToUSDTPrice) public onlyVault {
+        require(madtToUSDTPrice > 0, "Invalid MADT to USDT price");
+
+        // uint256 oldRebaseFactor = rebaseFactor;
+        uint256 scalingFactor = 100;
+
+        // Calculate the new rebase factor based on the ratio
+        uint256 newRebaseFactor = (rebaseFactor * madtToUSDTPrice) / scalingFactor;
+        rebaseFactor = newRebaseFactor;
+        // emit Rebase(oldRebaseFactor, rebaseFactor);
     }
 
     function decimals() public pure override returns (uint8) {

--- a/src/MockUSDT.sol
+++ b/src/MockUSDT.sol
@@ -9,7 +9,7 @@ contract MockUSDT is ERC20 {
     uint256 private constant INITIAL_SUPPLY = 1000e18;
 
     constructor() ERC20("Mock USDT", "USDT") {
-        _mint(msg.sender, 100000000000000000000);
+        _mint(msg.sender, 100000000000);
     }
 
     function decimals() public pure override returns (uint8) {

--- a/src/Vault.sol
+++ b/src/Vault.sol
@@ -35,10 +35,16 @@ contract Vault {
         @return bool True if the collateral was deposited successfully
     */
 
-    function depositCollateral(uint256 amountInUsd) public payable returns (bool) {
+    function depositCollateral(
+        uint256 amountInUsd
+    ) public payable returns (bool) {
         uint256 madValue = dataProvider.getMADValueInUSD();
         uint256 madAmount = (amountInUsd * (10 ** 8)) / madValue;
-        bool success = usdt.transferFrom(msg.sender, address(this), amountInUsd * (10 ** 6));
+        bool success = usdt.transferFrom(
+            msg.sender,
+            address(this),
+            amountInUsd * (10 ** 6)
+        );
         if (!success) revert Vault__TransferFailed();
 
         emit CollateralDeposited(msg.sender, amountInUsd * (10 ** 6));
@@ -54,7 +60,9 @@ contract Vault {
         @return bool True if the collateral was redeemed successfully
     */
 
-    function redeemCollateral(uint256 amountInUsd) public payable returns (bool) {
+    function redeemCollateral(
+        uint256 amountInUsd
+    ) public payable returns (bool) {
         uint256 madValue = dataProvider.getMADValueInUSD();
         uint256 madAmount = (amountInUsd * (10 ** 8)) / madValue;
 
@@ -73,5 +81,10 @@ contract Vault {
 
         emit CollateralRedeemed(msg.sender, amountInUsd);
         return success;
+    }
+
+    function rebase() public {
+        uint256 madValue = dataProvider.getMADValueInUSD();
+        madt.rebase(madValue);
     }
 }

--- a/src/Vault.sol
+++ b/src/Vault.sol
@@ -35,16 +35,10 @@ contract Vault {
         @return bool True if the collateral was deposited successfully
     */
 
-    function depositCollateral(
-        uint256 amountInUsd
-    ) public payable returns (bool) {
+    function depositCollateral(uint256 amountInUsd) public payable returns (bool) {
         uint256 madValue = dataProvider.getMADValueInUSD();
         uint256 madAmount = (amountInUsd * (10 ** 8)) / madValue;
-        bool success = usdt.transferFrom(
-            msg.sender,
-            address(this),
-            amountInUsd * (10 ** 6)
-        );
+        bool success = usdt.transferFrom(msg.sender, address(this), amountInUsd * (10 ** 6));
         if (!success) revert Vault__TransferFailed();
 
         emit CollateralDeposited(msg.sender, amountInUsd * (10 ** 6));
@@ -60,9 +54,7 @@ contract Vault {
         @return bool True if the collateral was redeemed successfully
     */
 
-    function redeemCollateral(
-        uint256 amountInUsd
-    ) public payable returns (bool) {
+    function redeemCollateral(uint256 amountInUsd) public payable returns (bool) {
         uint256 madValue = dataProvider.getMADValueInUSD();
         uint256 madAmount = (amountInUsd * (10 ** 8)) / madValue;
 

--- a/src/Vault.sol
+++ b/src/Vault.sol
@@ -37,7 +37,7 @@ contract Vault {
 
     function depositCollateral(uint256 amountInUsd) public payable returns (bool) {
         uint256 madValue = dataProvider.getMADValueInUSD();
-        uint256 madAmount = (amountInUsd * 1e18) / madValue;
+        uint256 madAmount = (amountInUsd * (10 ** 8)) / madValue;
         bool success = usdt.transferFrom(msg.sender, address(this), amountInUsd * (10 ** 6));
         if (!success) revert Vault__TransferFailed();
 
@@ -56,19 +56,19 @@ contract Vault {
 
     function redeemCollateral(uint256 amountInUsd) public payable returns (bool) {
         uint256 madValue = dataProvider.getMADValueInUSD();
-        uint256 madAmount = (amountInUsd * 1e18) / madValue;
+        uint256 madAmount = (amountInUsd * (10 ** 8)) / madValue;
 
         if (madt.balanceOf(msg.sender) < madAmount) {
             revert Vault__UserInsufficientBalance();
         }
 
-        if (usdt.balanceOf(address(this)) < amountInUsd * 1e6) {
+        if (usdt.balanceOf(address(this)) < amountInUsd * (10 ** 6)) {
             revert Vault__VaultInsufficientBalance();
         }
 
         madt.burn(msg.sender, madAmount);
 
-        bool success = usdt.transfer(msg.sender, amountInUsd * 1e6);
+        bool success = usdt.transfer(msg.sender, amountInUsd * (10 ** 6));
         if (!success) revert Vault__TransferFailed();
 
         emit CollateralRedeemed(msg.sender, amountInUsd);


### PR DESCRIPTION
This PR introduces several changes to ensure that MADT is able to honor redemptions in case of fluctuations in the USD/MAD rate. It also introduces a sample API request to two providers for the DON to execute.

**Changes**
- Rebase mechanism that inflates/deflates the supply.
- API request to [Exchangerate API](exchangerate-api.com) and [CurrencyAPI](https://currencyapi.com/). Other providers can be added and a median rate can be taken in consideration.
- Adding a `deployAll` script to enhance the dev UX.

